### PR TITLE
Add description of units to absorption docstring

### DIFF
--- a/src/uw_basic.jl
+++ b/src/uw_basic.jl
@@ -34,7 +34,19 @@ Compute volume acoustic absorption coefficient in water, given:
 - `depth` in meters
 - `pH` of water
 
-Implementation based on the Francois-Garrison model.
+The result is a unitless linear scale factor for sound pressure over the given `distance`. To get 
+absorption in terms of dB / m, set `distance = 1.0` and convert the result to decibels. For instance, 
+at a frequency of 100 kHz:
+
+```julia-repl
+julia> A = absorption(100e3, 1.0)
+0.9959084838594522
+
+julia> α = -20log10(A)
+0.035611359656810865
+```
+
+Implementation based on the Francois and Garrison (1982) model.
 """
 function absorption(frequency, distance=1000.0, salinity=35.0, temperature=27.0, depth=10.0, pH=8.1)
   f = frequency/1000.0


### PR DESCRIPTION
Adding a bit more information for `absorption`, following my question and @mchitre's answer in https://github.com/org-arl/UnderwaterAcoustics.jl/issues/54.