### PR TITLE
Improve modal impulse response performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ qdocs/_site
 qdocs/red.mat
 qdocs/.gitignore
 qdocs/_freeze
+UnderwaterAcoustics.code-workspace
+tmp

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnderwaterAcoustics"
 uuid = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/pekeris.jl
+++ b/src/pekeris.jl
@@ -336,7 +336,7 @@ function impulse_response(pm::AbstractModePropagationModel,
   nmodes = something(nmodes, max_modes)
   nmodes = min(nmodes, max_modes, length(arr))
   mintaps = ceil(Int, (R / arr[nmodes].v - R / arr[1].v) * fs)
-  N = nextfastfft(round(Int, (1 + taper) * mintaps))
+  N = nextfastfft(round(Int, (1 + 2 * taper) * mintaps))
   Δf = fs / N
   f = (0:N-1) .* Δf
   ndx = findall(fmin .< f .< fmax)
@@ -347,7 +347,7 @@ function impulse_response(pm::AbstractModePropagationModel,
   end
   X .*= cispi.(2f * Δt)
   x = √2 * ifft(X)  # factor of √2 to account for energy only in +ve freq
-  taper > 0 && (x .*= tukey(length(x), 2 * taper))
+  taper > 0 && (x .*= tukey(length(x), taper))
   if abstime
     x = vcat(zeros(eltype(x), round(Int, Δt * fs)), x)
   end


### PR DESCRIPTION
Modal impulse response could be very slow for long range propagation due to excessive modal dispersion. However, later modes may be heavily attenuated and therefore can be ignored. This PR improves the computational performance of `impulse_response()` for modal models, and improves some defaults. It also fixes a scaling bug.

### Key changes:

- The length of the impulse response in controlled by a delay spread estimate that ignores weak modal arrivals below a `threshold`.
- `fmin` and `fmax` now default to `0` and `fs/2`, but it is recommended that the user sets them as necessary for the application.
- `nmodes` controls the number of modes used in impulse response computation.
- `acausal` allows positioning of the impulse response to capture the acausal part of the response. This was previously hard coded to 20 ms.
- `taper` controls windowing of the impulse response to ensure it decays to 0 at the end of the FFT window.
