### PR TITLE
Performance improvements for channel transmission API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnderwaterAcoustics"
 uuid = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/api.jl
+++ b/src/api.jl
@@ -274,12 +274,12 @@ function transmit(ch::SampledPassbandChannel, x; txs=:, rxs=:, abstime=false, no
   all(rx ∈ 1:M for rx ∈ rxs) || error("Invalid receiver indices ($rxs ⊄ 1:$M)")
   nchannels(x) == length(txs) || error("Mismatched number of sources (expected $(length(txs)), actual $(nchannels(x)))")
   # simulate transmission
-  min_t0 = minimum(ch.t0s[txs,rxs])
+  min_t0, max_t0 = extrema(ch.t0s[txs,rxs])
   t0 = abstime ? 1 : min_t0
   flen = maximum(ir -> size(ir, 1), ch.irs[txs,rxs])
   x̄ = analytic(x)
   x̄ = vcat(x̄, zeros(eltype(x̄), flen - 1, size(x̄,2)))
-  ȳ = zeros(Base.promote_eltype(x̄, ch.irs[1]), size(x̄,1) + min_t0 - t0, length(rxs))
+  ȳ = zeros(Base.promote_eltype(x̄, ch.irs[1]), size(x̄,1) + max_t0 - t0, length(rxs))
   let x̄ = x̄     # avoid boxing of x̄ and resulting type instability
     Threads.@threads for i ∈ eachindex(rxs)
       for j ∈ eachindex(txs)

--- a/test/test_api_stdlib.jl
+++ b/test/test_api_stdlib.jl
@@ -51,6 +51,7 @@ end
   @test startswith(sprint(show, ch), "SampledPassbandChannel")
   @test ch.fs == 192000
   @test ch.noise === nothing
+  @test size(ch.irs) == size(ch.t0s)
   x = vcat(1.0, 0.5, zeros(98))
   y1 = @inferred transmit(ch, x)
   @test length(y1) ≥ length(x)
@@ -59,6 +60,14 @@ end
   y1[1:3] .= 0
   y1[129:131] .= 0
   @test all(abs.(y1) .< 1)
+  y2 = @inferred transmit(ch, x; abstime=true)
+  @test length(y2) ≥ length(y1)
+  y2 = y2[12816:end]
+  @test all(y2[1:3] .> 1)
+  @test all(y2[129:131] .< -1)
+  y2[1:3] .= 0
+  y2[129:131] .= 0
+  @test all(abs.(y2) .< 1)
   ch = @inferred channel(pm, tx, rx, 192000; noise=RedGaussianNoise(0.5e6))
   @test ch isa UnderwaterAcoustics.SampledPassbandChannel
   @test ch.fs == 192000


### PR DESCRIPTION
Improves performance of channel transmission API by:
1. Dispatching complex signal filtering to `SignalAnalysis.jl` rather than `DSP.jl`. A performance bug in `DSP.jl` causes complex filtering to be very very slow.
2. Caching only the necessary length of impulse response, thus reducing filter length.