### PR TITLE
Fix scaling of real / complex analytic signals when passing through a channel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnderwaterAcoustics"
 uuid = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/ext/ChainRulesExt.jl
+++ b/ext/ChainRulesExt.jl
@@ -1,33 +1,7 @@
 module ChainRulesExt
 
 using ChainRulesCore
-import UnderwaterAcoustics: _arr2ir, tmap
-
-function ChainRulesCore.rrule(::typeof(_arr2ir), ts, ϕs; T, t0, fs, n)
-  ir = _arr2ir(ts, ϕs; T, t0, fs, n)
-  function _arr2ir_pullback(dx)
-    dx = unthunk(dx)
-    T1 = promote_type(eltype(ts), eltype(dx))
-    T2 = promote_type(eltype(ϕs), eltype(dx))
-    dt = zeros(T1, length(ts))
-    dϕ = zeros(T2, length(ϕs))
-    for i ∈ eachindex(dt)
-      t = (ts[i] - t0) * fs + 1
-      t̄ = floor(Int, t)
-      α, β = sincospi(0.5 * (t - t̄))
-      if t̄ ≤ n
-        dϕ[i] += β * dx[t̄]
-        dt[i] -= 0.5π * fs * α * ϕs[i] * dx[t̄]
-      end
-      if t̄ < n
-        dϕ[i] += α * dx[t̄+1]
-        dt[i] += 0.5π * fs  * β * ϕs[i] * dx[t̄+1]
-      end
-    end
-    return NoTangent(), dt, dϕ
-  end
-  return ir, _arr2ir_pullback
-end
+import UnderwaterAcoustics: _arr2ir, tmap, _blackman
 
 function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(tmap), f, X::AbstractArray)
   cache = tmap(X) do x

--- a/src/api.jl
+++ b/src/api.jl
@@ -295,7 +295,7 @@ function transmit(ch::SampledPassbandChannel, x; txs=:, rxs=:, abstime=false, no
     noisy && ch.noise !== nothing && (ȳ .+= analytic(rand(ch.noise, size(ȳ); fs)))
     signal(ȳ, fs)
   else
-    y = real(ȳ)
+    y = real(ȳ) * sqrt(2)
     noisy && ch.noise !== nothing && (y .+= rand(ch.noise, size(y); fs))
     signal(y, fs)
   end


### PR DESCRIPTION
Fixes #72 

The difference in scaling between real / complex analytic signals was due to 2 reasons:

1. Real signals were converted to complex analytic and back, but the scaling of the conversion back was incorrect (fixed by multiplying by √2).
2. The ray model impulse response assigned energy of an arrival that was not exactly at an integer sample to the two neighboring samples. While this yields, _nice_ looking impulse responses, it has a poor frequency response. This led to some frequencies being amplified/attenuated and give incorrect scaling. The right way to do this is to sample fractional delay taps using a `sinc` filter. The problem with a `sinc` filter, however, is that it has an infinitely long response. We handle this by multiplying by a Blackman window of about 2 ms. This truncates the response in exchange of a slightly reduced bandwidth (as compared with Nyquist) for the impulse response. As long as the signal to transmit is within this bandwidth, the scaling is correct.

As a byproduct of implementing the new impulse response computation, we made it non-mutating. This allowed us to drop the Zygote chain rule for it.
