### PR TITLE
Update tut2 for Turing 0.41+ VI API changes

### DIFF
--- a/qdocs/tut2.qmd
+++ b/qdocs/tut2.qmd
@@ -69,6 +69,7 @@ We define the probabilistic model as a [`Turing.jl`](https://github.com/TuringLa
 #| output: false
 using Turing
 using Random
+using Bijectors
 
 # depths d, frequencies f, transmission loss measurements x
 @model function geoacoustic(d, f, x)
@@ -88,7 +89,14 @@ Once we have the model defined, we can run Bayesian inference on it. We could ei
 #| output: false
 # this may take a minute or two to run...
 m = geoacoustic(data.depth, data.frequency, data.xloss)
-q,_ = vi(MersenneTwister(1), m, q_fullrank_gaussian(m), 1000)
+q_raw = vi(MersenneTwister(1), m, q_fullrank_gaussian, 1000)
+# Bijector mapping physical -> unconstrained, in the order priors are declared
+b = Stacked([
+  bijector(Uniform(1300.0, 1700.0)),
+  bijector(Uniform(750.0, 2000.0)),
+  bijector(Uniform(0.0, 0.003)),
+])
+q = transformed(q_raw.q, inverse(b))
 ```
 
 The returned `q` is a 3-dimensional posterior probability distribution over the parameters `ρ`, `c` and `δ`. We can estimate the mean of the distribution by drawing random variates and taking the sample mean:

--- a/qdocs/tut3.qmd
+++ b/qdocs/tut3.qmd
@@ -53,6 +53,7 @@ We can model this as a Bayesian inference problem using [`Turing.jl`](https://gi
 #| output: false
 using Turing
 using Random
+using Bijectors
 
 @model function pmodel(data)
   h  ~ Normal(20.0, 0.1)
@@ -64,7 +65,16 @@ using Random
 end
 
 m = pmodel(data)
-q,_ = vi(MersenneTwister(1), m, q_meanfield_gaussian(m), 10000)
+q_raw = vi(MersenneTwister(1), m, q_meanfield_gaussian, 250000)
+
+# Bijector mapping physical -> unconstrained, in the order priors are declared
+b = Stacked([
+  bijector(Normal(20.0, 0.1)),
+  bijector(Uniform(0.0, 250.0)),
+  bijector(Normal(7.0, 1.0)),
+  bijector(Uniform(0.0, 20.0)),
+])
+q = transformed(q_raw.q, inverse(b))
 
 # extract mean values of parameters h, r, d1 and d2
 μ = mean(rand(q, 10000); dims=2)


### PR DESCRIPTION
Updates `tut2.qmd` for the Turing 0.41+ VI API:

- `vi` now returns a `VIResult` rather than `(q, info)`
- `q_fullrank_gaussian` is passed as a family-constructor function, not called with the model
- `Bijectors.bijector(::DynamicPPL.Model)` is no longer part of the public API, so the bijector is constructed manually from the Uniform priors and used to wrap `q_raw.q` in a `TransformedDistribution`. This preserves the rest of the tutorial (`pdf(q, [...])`, `rand(q, n)`, plots) as originally written.

Plan to follow up with a Turing.jl issue proposing that `VIResult` expose `pdf` and `rand` on the constrained parameter space directly, so this workaround isn't needed long-term.

Question: this PR only changes the source `tut2.qmd`. I haven't regenerated the rendered HTML. Should I do that locally and include it, or does CI handle it on merge? It seems like it does not, let me know whether I should do it or not, I will work on tut3 in the meantime.