### PR TITLE
Add water-column scatterers to environment API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "UnderwaterAcoustics"
 uuid = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.7.5"
+version = "0.8.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -32,6 +33,7 @@ ChainRulesCore = "1.25"
 Colors = "0.12,0.13"
 DSP = "0.6,0.7,0.8.2"
 FFTW = "1.8"
+ForwardDiff = "0.10.36, 1"
 InteractiveUtils = "1"
 Interpolations = "0.14,0.15,0.16"
 Logging = "1"

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -6,6 +6,7 @@ using UnderwaterAcoustics
 import UnderwaterAcoustics: AbstractAcousticSource, AbstractAcousticReceiver, RayArrival, value
 import UnderwaterAcoustics: SampledFieldZ, SampledFieldX, SampledFieldXZ, SampledFieldXY, ModeArrival
 import UnderwaterAcoustics: BasebandReplayChannel, DepthDependent, PositionDependent
+import UnderwaterAcoustics: Scatterer, boundary_points
 import DSP: amp2db
 
 @recipe function plot(env::UnderwaterEnvironment)
@@ -26,6 +27,16 @@ import DSP: amp2db
     seriestype := :path
     linecolor := :brown
     xrange, [-value(z2, (x, 0.0)) for x ∈ xrange]
+  end
+  for s ∈ env.scatterers
+    ndims(s.shape) == 2 || continue
+    pts = boundary_points(s.shape; n=64)
+    @series begin
+      seriestype := :shape
+      linecolor := :black
+      fillcolor := :gray
+      [p.x for p ∈ pts], [p.z for p ∈ pts]
+    end
   end
 end
 

--- a/qdocs/_quarto.yml
+++ b/qdocs/_quarto.yml
@@ -17,6 +17,7 @@ website:
       - text: <b>Guides</b>
       - pos.qmd
       - fields.qmd
+      - scatterers.qmd
       - ext.qmd
       - porting.qmd
       - python.qmd

--- a/qdocs/api.qmd
+++ b/qdocs/api.qmd
@@ -125,6 +125,28 @@ const ElasticSandySilt         = ElasticBoundary(SandySilt, 13.4u"dB/m/kHz")
 ```
 :::
 
+## Scatterers
+
+```{julia}
+#| echo: false
+#| output: asis
+jdoc(UnderwaterAcoustics, :Scatterer)
+jdoc(UnderwaterAcoustics, :AbstractShape)
+jdoc(UnderwaterAcoustics, :Ellipse)
+jdoc(UnderwaterAcoustics, :ParametricCurve)
+jdoc(UnderwaterAcoustics, :ParametricSurface)
+jdoc(UnderwaterAcoustics, :boundary_point)
+jdoc(UnderwaterAcoustics, :normal)
+jdoc(UnderwaterAcoustics, :curvature)
+jdoc(UnderwaterAcoustics, :distance)
+jdoc(UnderwaterAcoustics, :boundary_projection)
+jdoc(UnderwaterAcoustics, :intersect_ray)
+jdoc(UnderwaterAcoustics, :is_inside)
+jdoc(UnderwaterAcoustics, :boundary_points)
+jdoc(UnderwaterAcoustics, :bounding_box)
+jdoc(UnderwaterAcoustics, :has_scatterers)
+```
+
 ## Sources and receivers
 
 ```{julia}

--- a/qdocs/ext.qmd
+++ b/qdocs/ext.qmd
@@ -97,3 +97,87 @@ jdoc(UnderwaterAcoustics, :transmit, 1)
 ```
 
 In some cases (e.g. channel replay techniques), a channel model may be defined without the need to derive it from a propagation model. In such a case, one may extend `UnderwaterAcoustics.jl` by directly defining the channel model.
+
+## Scatterers and shapes {#scatterers-and-shapes}
+
+Environments may contain [scatterers](scatterers.qmd) — non-penetrable objects in the water column described by a geometric shape and an acoustic boundary condition:
+```{julia}
+#| echo: false
+#| output: asis
+jdoc(UnderwaterAcoustics, :Scatterer)
+```
+Propagation models that support scattering should query `has_scatterers(env)` and consume the scatterer geometry through the shape API described below. Models that do not support scattering should reject environments with scatterers with a clear error message (all built-in models do so).
+
+### The parametric boundary map
+
+The fundamental geometric primitive of a shape is a parametric map of its closed boundary over a unit parameter domain. A new shape type (let's call it `MyShape`) extends:
+```{julia}
+#| echo: false
+#| output: asis
+jdoc(UnderwaterAcoustics, :AbstractShape)
+```
+and must define just two methods:
+```julia
+Base.ndims(shape::MyShape) = 2       # spatial dimension (2 or 3)
+boundary_point(shape::MyShape, u)    # parametric boundary position map
+```
+```{julia}
+#| echo: false
+#| output: asis
+jdoc(UnderwaterAcoustics, :boundary_point)
+```
+
+Everything else is derived automatically. In particular, boundary normals and curvatures are computed from `boundary_point()` using automatic differentiation if the shape does not provide them. A shape may provide analytic implementations for accuracy and speed:
+```{julia}
+#| echo: false
+#| output: asis
+jdoc(UnderwaterAcoustics, :normal)
+jdoc(UnderwaterAcoustics, :curvature)
+```
+
+For simple shapes, one may avoid defining a new type altogether by wrapping a parametric function:
+```{julia}
+#| echo: false
+#| output: asis
+jdoc(UnderwaterAcoustics, :ParametricCurve)
+jdoc(UnderwaterAcoustics, :ParametricSurface)
+```
+
+### Derived geometry queries
+
+The framework provides a set of derived queries with generic fallbacks based on `boundary_point()`. These are properties of the shape (not of any particular solver), so any propagation model gets them for free. A shape may override any of them with analytic implementations (as `Ellipse` does):
+```{julia}
+#| echo: false
+#| output: asis
+jdoc(UnderwaterAcoustics, :distance)
+jdoc(UnderwaterAcoustics, :boundary_projection)
+jdoc(UnderwaterAcoustics, :intersect_ray)
+jdoc(UnderwaterAcoustics, :is_inside)
+jdoc(UnderwaterAcoustics, :boundary_points)
+jdoc(UnderwaterAcoustics, :bounding_box)
+```
+
+::: {.callout-warning title="The `distance()` contract"}
+Solvers that trace curved rays are expected to find boundary interactions as root-crossings of the signed `distance()` along the ray. A custom shape that overrides `distance()` may return a conservative lower bound on the magnitude *far* from the boundary, but near the boundary the distance must be sign-exact with the correct zero level set — a globally loose bound would make a solver fire the boundary event at the wrong place, or never detect it. The generic fallback and the analytic `Ellipse` implementation satisfy this automatically.
+:::
+
+The generic fallbacks converge their inner minimizations to true stationary points, so ForwardDiff duals propagate correctly through them (by the envelope theorem) — custom shapes defined by a differentiable `boundary_point()` are fully differentiable with respect to both query positions and shape parameters.
+
+### Example: a custom shape from one function
+
+A closed curve defined by a single (differentiable) function is a fully functional shape:
+```{julia}
+using UnderwaterAcoustics
+
+# a lobed blob centered at (500, -40), with radius varying between 16 and 24 m
+blob = ParametricCurve() do u
+  r = 20 + 4 * cospi(6u)
+  (500 + r * cospi(2u), -40 + r * sinpi(2u))
+end
+
+@info is_inside(blob, (x=520, z=-40))
+@info distance(blob, (x=500, z=-70))
+@info intersect_ray(blob, (x=0, z=-40), (x=1, z=0))
+```
+Normals, curvatures, distances and ray intersections are all computed automatically from the parametric function.
+

--- a/qdocs/ext.qmd
+++ b/qdocs/ext.qmd
@@ -100,7 +100,7 @@ In some cases (e.g. channel replay techniques), a channel model may be defined w
 
 ## Scatterers and shapes {#scatterers-and-shapes}
 
-Environments may contain [scatterers](scatterers.qmd) — non-penetrable objects in the water column described by a geometric shape and an acoustic boundary condition:
+Environments may contain [scatterers](scatterers.qmd) — objects in the water column described by a geometric shape and an acoustic boundary condition:
 ```{julia}
 #| echo: false
 #| output: asis

--- a/qdocs/scatterers.qmd
+++ b/qdocs/scatterers.qmd
@@ -15,7 +15,7 @@ default(size=(600, 400))
 
 ## Objects in the water column
 
-Most of the environmental description in `UnderwaterAcoustics.jl` deals with a stratified ocean bounded by the sea surface and the seabed. Sometimes we also wish to model discrete objects in the water column — a submerged target, a fish school, a bubble cloud, etc. Such objects are described as **scatterers**: non-penetrable objects with a geometric shape and an acoustic boundary condition on their surface.
+Most of the environmental description in `UnderwaterAcoustics.jl` deals with a stratified ocean bounded by the sea surface and the seabed. Sometimes we also wish to model discrete objects in the water column — a submerged target, a fish school, a bubble cloud, etc. Such objects are described as **scatterers**: objects with a geometric shape and an acoustic boundary condition on their surface. The environment only describes the geometry and the surface property — how a scatterer interacts with the sound field (including whether it is treated as impenetrable) is up to each propagation model.
 
 A scatterer is created from a shape and a boundary condition:
 ```{julia}
@@ -34,11 +34,11 @@ env = UnderwaterEnvironment(bathymetry=100.0, scatterers=sc)
 ```
 The `scatterers` keyword accepts a single scatterer, or a tuple/vector of scatterers. We can visualize the environment with the scatterer:
 ```{julia}
-plot(env; xlims=(0, 1000))
+plot(env; xlims=(0, 1000), size=(600, 250), dpi=100)
 ```
 
 ::: {.callout-warning title="Model support"}
-The built-in propagation models (`PekerisRayTracer`, `PekerisModeSolver`) do **not** support scattering, and refuse to work with environments containing scatterers. The scatterer description and its geometry API are intended for use by propagation models in other packages that compute scattering.
+The built-in propagation models (`PekerisRayTracer`, `PekerisModeSolver`) do **not** support scattering, and refuse to work with environments containing scatterers. The scatterer description and its geometry API are intended for use by propagation models in other packages that compute scattering, e.g. [`RaySolver`](raysolver.qmd) from `AcousticRayTracers.jl`.
 
 Models that support scatterers are expected to apply the boundary condition of the scatterer under a local tangent-plane (Kirchhoff) approximation, i.e., apply the reflection coefficient of the boundary using the local surface normal at each interaction point. This approximation is valid when the local radius of curvature of the scatterer is much larger than the acoustic wavelength.
 :::

--- a/qdocs/scatterers.qmd
+++ b/qdocs/scatterers.qmd
@@ -1,0 +1,71 @@
+---
+title: "Scatterers"
+engine: julia
+---
+
+{{< include jdoc.snippet >}}
+
+```{julia}
+#| echo: false
+#| output: false
+using UnderwaterAcoustics
+using Plots
+default(size=(600, 400))
+```
+
+## Objects in the water column
+
+Most of the environmental description in `UnderwaterAcoustics.jl` deals with a stratified ocean bounded by the sea surface and the seabed. Sometimes we also wish to model discrete objects in the water column — a submerged target, a fish school, a bubble cloud, etc. Such objects are described as **scatterers**: non-penetrable objects with a geometric shape and an acoustic boundary condition on their surface.
+
+A scatterer is created from a shape and a boundary condition:
+```{julia}
+sc = Scatterer(Ellipse(500.0, -40.0, 20.0, 8.0; θ=30u"°"))
+```
+The default boundary condition is a `RigidBoundary` (sound-hard object). Other boundary conditions may be specified, e.g. a `PressureReleaseBoundary` for a sound-soft object such as a bubble cloud:
+```{julia}
+Scatterer(Ellipse(500.0, -40.0, 20.0, 8.0), PressureReleaseBoundary)
+```
+
+The only shape currently shipped with `UnderwaterAcoustics.jl` is a 2-D `Ellipse` in the x–z plane, but arbitrary shapes may be defined by a parametric function of the boundary (see [custom shapes](#custom-shapes) below), and 3-D shapes (e.g. ellipsoids) are expected to be added in the future.
+
+Scatterers are part of the environmental description:
+```{julia}
+env = UnderwaterEnvironment(bathymetry=100.0, scatterers=sc)
+```
+The `scatterers` keyword accepts a single scatterer, or a tuple/vector of scatterers. We can visualize the environment with the scatterer:
+```{julia}
+plot(env; xlims=(0, 1000))
+```
+
+::: {.callout-warning title="Model support"}
+The built-in propagation models (`PekerisRayTracer`, `PekerisModeSolver`) do **not** support scattering, and refuse to work with environments containing scatterers. The scatterer description and its geometry API are intended for use by propagation models in other packages that compute scattering.
+
+Models that support scatterers are expected to apply the boundary condition of the scatterer under a local tangent-plane (Kirchhoff) approximation, i.e., apply the reflection coefficient of the boundary using the local surface normal at each interaction point. This approximation is valid when the local radius of curvature of the scatterer is much larger than the acoustic wavelength.
+:::
+
+## Geometry queries
+
+Shapes support a set of geometric queries that propagation models (or users) may use:
+```{julia}
+shape = Ellipse(500.0, -40.0, 20.0, 8.0; θ=30u"°")
+@info boundary_point(shape, 0.25)              # point on the boundary at parameter u ∈ [0,1]
+@info normal(shape, 0.25)                      # unit outward normal at parameter u
+@info curvature(shape, 0.25)                   # signed curvature at parameter u
+@info distance(shape, (x=500, z=-70))          # signed distance (negative inside)
+@info is_inside(shape, (x=500, z=-40))         # is a position inside the shape?
+@info intersect_ray(shape, (x=0, z=-40), (x=1, z=0))  # nearest ray-boundary intersection
+@info bounding_box(shape)                      # axis-aligned bounding box
+```
+`boundary_projection()` finds the boundary point nearest to a given position, and returns it together with the local normal, curvature and signed distance. `boundary_points()` samples the boundary, e.g. for plotting.
+
+All shape geometry is differentiable: gradients propagate through shape parameters and query positions with automatic differentiation (e.g. `ForwardDiff`), enabling optimization and inversion of scatterer location, size and orientation.
+
+## Custom shapes {#custom-shapes}
+
+Arbitrary 2-D shapes may be defined by a single parametric function tracing the closed boundary counter-clockwise in the x–z plane as `u` sweeps `[0, 1]`:
+```{julia}
+# a circle of radius 10 m centered at (500, -40)
+circle = ParametricCurve(u -> (500 + 10 * cospi(2u), -40 + 10 * sinpi(2u)))
+@info distance(circle, (x=500, z=-60))
+```
+Normals, curvatures and all derived queries are automatically computed from the parametric function using automatic differentiation. 3-D shapes may similarly be defined with `ParametricSurface`. See the [extending documentation](ext.qmd#scatterers-and-shapes) for details on the shape API, including how to define new shape types with analytic geometry.

--- a/src/UnderwaterAcoustics.jl
+++ b/src/UnderwaterAcoustics.jl
@@ -9,6 +9,7 @@ include("basic.jl")
 # propagation modeling
 include("api.jl")
 include("stdlib.jl")
+include("scatterers.jl")
 include("pekeris.jl")
 include("adiabatic.jl")
 include("replay.jl")

--- a/src/adiabatic.jl
+++ b/src/adiabatic.jl
@@ -24,6 +24,7 @@ struct AdiabaticExt{T1,T2,T3} <: AbstractModePropagationModel
   dz::Float64
   reciprocal::Bool
   function AdiabaticExt(model::Type{<:AbstractModePropagationModel}, env; dx=0.0, dz=0.0, reciprocal=false, kwargs...)
+    has_scatterers(env) && error("AdiabaticExt does not support scatterers")
     new{typeof(env),typeof(kwargs),model}(env, kwargs, dx, dz, reciprocal)
   end
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -339,10 +339,11 @@ parameters are supported:
 - `density` = density model
 - `seabed` = seabed sediment model
 - `surface` = surface model
+- `scatterers` = scatterer, or tuple/vector of scatterers, in the water column
 
 All parameters are optional and have default values.
 """
-struct UnderwaterEnvironment{T1,T2,T3,T4,T5,T6,T7,T8,T9}
+struct UnderwaterEnvironment{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10}
   bathymetry::T1
   altimetry::T2
   temperature::T3
@@ -352,6 +353,7 @@ struct UnderwaterEnvironment{T1,T2,T3,T4,T5,T6,T7,T8,T9}
   density::T7
   seabed::T8
   surface::T9
+  scatterers::T10
 end
 
 function UnderwaterEnvironment(;
@@ -364,6 +366,7 @@ function UnderwaterEnvironment(;
   density = nothing,
   seabed = RigidBoundary,
   surface = PressureReleaseBoundary,
+  scatterers = (),
 )
   bathymetry isa Number && (bathymetry = in_units(u"m", bathymetry))
   altimetry isa Number && (altimetry = in_units(u"m", altimetry))
@@ -373,8 +376,10 @@ function UnderwaterEnvironment(;
   density = something(density, water_density(temperature, salinity))
   soundspeed isa Number && (soundspeed = in_units(u"m/s", soundspeed))
   soundspeed = something(soundspeed, UnderwaterAcoustics.soundspeed(temperature, salinity))
+  scatterers isa AbstractVector && (scatterers = Tuple(scatterers))
+  scatterers isa Tuple || (scatterers = (scatterers,))
   UnderwaterEnvironment(
-    bathymetry, altimetry, temperature, salinity, pH, soundspeed, density, seabed, surface
+    bathymetry, altimetry, temperature, salinity, pH, soundspeed, density, seabed, surface, scatterers
   )
 end
 
@@ -389,6 +394,7 @@ function Base.show(io::IO, env::UnderwaterEnvironment)
   println(io, "  density = $(env.density), ")
   println(io, "  seabed = $(env.seabed), ")
   println(io, "  surface = $(env.surface), ")
+  isempty(env.scatterers) || println(io, "  scatterers = ($(join(repr.(env.scatterers), ", "))), ")
   println(io, ")")
 end
 
@@ -427,7 +433,8 @@ function env_type(env::UnderwaterEnvironment)
   d = value(env.density, (0,0,0))
   r1 = real(reflection_coef(env.surface, 1000.0, 0.0, d, c))
   r2 = real(reflection_coef(env.seabed, 1000.0, 0.0, d, c))
-  promote_type(typeof(a), typeof(b), typeof(c), typeof(s), typeof(pH), typeof(d), typeof(r1), typeof(r2))
+  T = promote_type(typeof(a), typeof(b), typeof(c), typeof(s), typeof(pH), typeof(d), typeof(r1), typeof(r2))
+  isempty(env.scatterers) ? T : promote_type(T, map(_geom_type, env.scatterers)...)
 end
 
 ###############################################################################

--- a/src/pekeris.jl
+++ b/src/pekeris.jl
@@ -27,6 +27,7 @@ struct PekerisRayTracer{T1,T2,T3,T4,T5,T6,T7,T8} <: AbstractRayPropagationModel
   max_bounces::Int  # maximum number of bounces
   function PekerisRayTracer(env; max_bounces=3)
     max_bounces ≥ 0 || error("Maximum number of bounces cannot be negative")
+    has_scatterers(env) && error("PekerisRayTracer does not support scatterers")
     is_isovelocity(env) || error("Environment must be iso-velocity")
     is_range_dependent(env) && error("Environment must be range independent")
     is_constant(env.temperature) || error("Temperature must be constant")
@@ -191,6 +192,7 @@ struct PekerisModeSolver{T1,T2,T3,T4,T5,T6,T7,T8} <: AbstractModePropagationMode
   nmodes::Int       # maximum number of modes (0 for no limit)
   cache::Dict{Float64,Vector{Float64}}    # cached solutions ω -> γ
   function PekerisModeSolver(env; ngrid=0, nmodes=0)
+    has_scatterers(env) && error("PekerisModeSolver does not support scatterers")
     is_isovelocity(env) || error("Environment must be iso-velocity")
     is_range_dependent(env) && error("Environment must be range independent")
     is_constant(env.temperature) || error("Temperature must be constant")

--- a/src/scatterers.jl
+++ b/src/scatterers.jl
@@ -523,10 +523,12 @@ abstract type AbstractScatterer end
     Scatterer(shape, boundary)
 
 Create a scatterer with the given `shape` and acoustic `boundary` condition.
-A scatterer is a non-penetrable object in the water column, described by its
-geometry (an [`AbstractShape`](@ref)) and the acoustic property of its surface
-(an `AbstractAcousticBoundary`, e.g. `RigidBoundary` for a sound-hard object
-or `PressureReleaseBoundary` for a sound-soft object such as a bubble cloud).
+A scatterer is an object in the water column, described by its geometry (an
+[`AbstractShape`](@ref)) and the acoustic property of its surface (an
+`AbstractAcousticBoundary`, e.g. `RigidBoundary` for a sound-hard object or
+`PressureReleaseBoundary` for a sound-soft object such as a bubble cloud).
+How the boundary condition is applied — including whether the object is
+treated as impenetrable — is determined by the propagation model.
 
 Propagation models that support scatterers are expected to apply the boundary
 condition under a local tangent-plane (Kirchhoff) approximation: the reflection

--- a/src/scatterers.jl
+++ b/src/scatterers.jl
@@ -1,0 +1,571 @@
+import ForwardDiff
+
+export AbstractShape, Ellipse, ParametricCurve, ParametricSurface, Scatterer
+export boundary_point, normal, curvature, distance, boundary_projection
+export intersect_ray, is_inside, boundary_points, bounding_box, has_scatterers
+
+###############################################################################
+### shapes API
+
+"""
+Superclass for all scatterer shapes.
+
+A shape describes the geometry of a closed object through a parametric map of
+its boundary over a unit parameter domain. The boundary of a 2-D shape is a
+curve parametrized by `u ∈ [0,1]`, and the boundary of a 3-D shape is a surface
+parametrized by `(u, v) ∈ [0,1]²`. A concrete shape must define:
+
+- `Base.ndims(shape)` — spatial dimension of the shape (2 or 3)
+- `boundary_point(shape, u...)` — parametric boundary position map
+
+Optionally, a shape may provide analytic `normal()` and `curvature()` methods;
+if absent, they are automatically derived from `boundary_point()` using
+automatic differentiation. A shape may also override the derived queries
+`distance()`, `boundary_projection()`, `intersect_ray()`, `is_inside()`,
+`boundary_points()`, `bounding_box()` and `location()` with analytic
+implementations for speed and accuracy.
+"""
+abstract type AbstractShape end
+
+"""
+    boundary_point(shape, u)
+    boundary_point(shape, u, v)
+
+Get the position on the boundary of `shape` at the given boundary parameters.
+The boundary of a 2-D shape is parametrized by a single parameter `u ∈ [0,1]`,
+and the boundary of a 3-D shape by two parameters `(u, v) ∈ [0,1]²`. The
+parametric map must trace the full closed boundary as the parameters sweep the
+unit domain, with `u = 0` and `u = 1` mapping to the same point. The position
+is returned as an `XYZ` named tuple with coordinates in meters.
+
+2-D shapes lie in the x–z plane (`y = 0`), with `z` negative downward. The
+boundary of a 2-D shape must be traversed counter-clockwise (with `x` rightward
+and `z` upward) as `u` increases, so that automatically derived normals point
+outward. Similarly, the parametrization of a 3-D shape must be right-handed
+(`∂p/∂u × ∂p/∂v` pointing outward).
+"""
+function boundary_point end
+
+"""
+    normal(shape, u)
+    normal(shape, u, v)
+
+Get the unit outward normal to the boundary of `shape` at the given boundary
+parameters, as an `XYZ` named tuple. If a shape does not provide an analytic
+normal, it is derived from `boundary_point()` using automatic differentiation.
+"""
+function normal(shape::AbstractShape, u)
+  dx, dz = _dbdu(shape, u)
+  m = hypot(dz, dx)
+  xyz(dz / m, -dx / m)
+end
+
+function normal(shape::AbstractShape, u, v)
+  pu = _dbduv(shape, u, v, 1)
+  pv = _dbduv(shape, u, v, 2)
+  nx = pu[2] * pv[3] - pu[3] * pv[2]
+  ny = pu[3] * pv[1] - pu[1] * pv[3]
+  nz = pu[1] * pv[2] - pu[2] * pv[1]
+  m = hypot(nx, ny, nz)
+  xyz(nx / m, ny / m, nz / m)
+end
+
+"""
+    curvature(shape, u)
+    curvature(shape, u, v)
+
+Get the signed curvature (in 1/m) of the boundary of a 2-D `shape` at boundary
+parameter `u`. The curvature is positive where the boundary curves toward the
+interior of the shape (convex), and negative where it curves away (concave).
+If a shape does not provide an analytic curvature, it is derived from
+`boundary_point()` using automatic differentiation.
+
+The return convention for the curvature of 3-D shapes is not yet settled, and
+`missing` is returned for 3-D shapes that do not provide a curvature.
+"""
+function curvature(shape::AbstractShape, u)
+  fx = u -> boundary_point(shape, u).x
+  fz = u -> boundary_point(shape, u).z
+  x′ = ForwardDiff.derivative(fx, u)
+  z′ = ForwardDiff.derivative(fz, u)
+  x″ = ForwardDiff.derivative(u -> ForwardDiff.derivative(fx, u), u)
+  z″ = ForwardDiff.derivative(u -> ForwardDiff.derivative(fz, u), u)
+  (x′ * z″ - z′ * x″) / hypot(x′, z′)^3
+end
+
+curvature(shape::AbstractShape, u, v) = missing
+
+"""
+    distance(shape, pos)
+
+Get the signed distance (in meters) from position `pos` to the boundary of
+`shape`. The distance is negative if `pos` is inside the shape, positive if
+outside, and zero on the boundary. The magnitude is the Euclidean distance to
+the nearest boundary point. A shape may return a conservative lower bound on
+the magnitude far away from the boundary, but the distance must be exact (with
+the correct sign and zero level set) near the boundary.
+
+For 2-D shapes, the distance is computed in the x–z plane, ignoring the `y`
+coordinate of `pos`.
+"""
+distance(shape::AbstractShape, pos::XYZ) = boundary_projection(shape, pos).distance
+distance(shape::AbstractShape, pos) = distance(shape, xyz(pos))
+
+"""
+    boundary_projection(shape, pos)
+
+Project position `pos` onto the boundary of `shape`, i.e., find the boundary
+point nearest to `pos`. Returns a named tuple with fields:
+
+- `u`: boundary parameter(s) of the nearest boundary point
+- `point`: position of the nearest boundary point
+- `normal`: unit outward normal at that point
+- `curvature`: curvature at that point
+- `distance`: signed distance from `pos` to the boundary (negative inside)
+
+For 2-D shapes, the projection is computed in the x–z plane, ignoring the `y`
+coordinate of `pos`.
+"""
+function boundary_projection(shape::AbstractShape, pos::XYZ)
+  ndims(shape) == 2 || error("Generic boundary_projection is currently only available for 2-D shapes")
+  n = 64
+  # coarse global search over the parameter domain, followed by Newton refinement
+  u = 0 / n
+  d² = _dist²(shape, u, pos)
+  for i ∈ 1:n-1
+    d²ᵢ = _dist²(shape, i / n, pos)
+    d²ᵢ < d² && ((u, d²) = (i / n, d²ᵢ))
+  end
+  u = _newton_projection(shape, float(u), pos, 1 / 2n)
+  _projection_bundle(shape, u, pos)
+end
+
+boundary_projection(shape::AbstractShape, pos) = boundary_projection(shape, xyz(pos))
+
+"""
+    intersect_ray(shape, origin, dir)
+
+Find the nearest intersection of the ray `origin + t * dir` (for `t ≥ 0`) with
+the boundary of `shape`. Returns `nothing` if the ray does not intersect the
+boundary, and otherwise a named tuple with fields:
+
+- `t`: ray parameter at the intersection (distance along the ray in units of
+  the length of `dir`)
+- `u`: boundary parameter(s) of the intersection point
+- `point`: position of the intersection point
+- `normal`: unit outward normal at the intersection point
+- `curvature`: curvature at the intersection point
+
+For 2-D shapes, the intersection is computed in the x–z plane, ignoring the
+`y` coordinates of `origin` and `dir`.
+"""
+function intersect_ray(shape::AbstractShape, origin::XYZ, dir::XYZ)
+  ndims(shape) == 2 || error("Generic intersect_ray is currently only available for 2-D shapes")
+  n = 256
+  # seed candidates from a sampled polygon, then refine on the parametric system
+  pts = boundary_points(shape; n)
+  best = nothing
+  for i ∈ 1:n
+    p1 = pts[i]
+    p2 = pts[i+1]
+    # solve origin + t dir = p1 + s (p2 - p1) for (t, s)
+    ex = p2.x - p1.x
+    ez = p2.z - p1.z
+    det = dir.z * ex - dir.x * ez
+    det == 0 && continue
+    bx = p1.x - origin.x
+    bz = p1.z - origin.z
+    t = (bz * ex - bx * ez) / det
+    s = (dir.x * bz - dir.z * bx) / det
+    (-0.01 ≤ s ≤ 1.01 && t ≥ -1e-6) || continue
+    u, t = _newton_ray(shape, float((i - 1 + s) / n), float(t), origin, dir)
+    t ≥ 0 || continue
+    (best === nothing || t < best[2]) && (best = (u, t))
+  end
+  best === nothing && return nothing
+  u, t = best
+  u = mod(u, 1)
+  (t=t, u=u, point=boundary_point(shape, u), normal=normal(shape, u), curvature=curvature(shape, u))
+end
+
+intersect_ray(shape::AbstractShape, origin, dir) = intersect_ray(shape, xyz(origin), xyz(dir))
+
+"""
+    is_inside(shape, pos)
+
+Return `true` if position `pos` is strictly inside `shape`, and `false`
+otherwise. For 2-D shapes, the test is performed in the x–z plane, ignoring
+the `y` coordinate of `pos`.
+"""
+is_inside(shape::AbstractShape, pos::XYZ) = distance(shape, pos) < 0
+is_inside(shape::AbstractShape, pos) = is_inside(shape, xyz(pos))
+
+"""
+    boundary_points(shape; n=128)
+
+Sample points on the boundary of `shape`, e.g. for plotting. For 2-D shapes,
+`n+1` points tracing the closed boundary are returned (with the first and last
+point coinciding). For 3-D shapes, points sampled on an `(n+1) × (n+1)` grid
+over the parameter domain are returned.
+"""
+function boundary_points(shape::AbstractShape; n=128)
+  if ndims(shape) == 2
+    [boundary_point(shape, u) for u ∈ range(0, 1; length=n+1)]
+  else
+    vec([boundary_point(shape, u, v) for u ∈ range(0, 1; length=n+1), v ∈ range(0, 1; length=n+1)])
+  end
+end
+
+"""
+    bounding_box(shape)
+
+Get an axis-aligned bounding box of `shape`, as a named tuple `(min, max)` of
+positions. The generic implementation estimates the box from sampled boundary
+points, and may slightly underestimate the extent of the shape.
+"""
+function bounding_box(shape::AbstractShape)
+  pts = boundary_points(shape; n=256)
+  (min=xyz(minimum(p.x for p ∈ pts), minimum(p.y for p ∈ pts), minimum(p.z for p ∈ pts)),
+   max=xyz(maximum(p.x for p ∈ pts), maximum(p.y for p ∈ pts), maximum(p.z for p ∈ pts)))
+end
+
+"""
+    location(shape::AbstractShape)
+    location(s::Scatterer)
+
+Get the location of the center of a shape or scatterer.
+"""
+function location(shape::AbstractShape)
+  bb = bounding_box(shape)
+  xyz((bb.min.x + bb.max.x) / 2, (bb.min.y + bb.max.y) / 2, (bb.min.z + bb.max.z) / 2)
+end
+
+### AD helpers for shapes that only define boundary_point()
+
+# ∂/∂u of the x and z coordinates of the boundary of a 2-D shape
+function _dbdu(shape::AbstractShape, u)
+  dx = ForwardDiff.derivative(u -> boundary_point(shape, u).x, u)
+  dz = ForwardDiff.derivative(u -> boundary_point(shape, u).z, u)
+  (dx, dz)
+end
+
+# partial derivative of the boundary of a 3-D shape wrt parameter i
+function _dbduv(shape::AbstractShape, u, v, i)
+  f = i == 1 ? (u -> boundary_point(shape, u, v)) : (v -> boundary_point(shape, u, v))
+  w = i == 1 ? u : v
+  (ForwardDiff.derivative(w -> f(w).x, w),
+   ForwardDiff.derivative(w -> f(w).y, w),
+   ForwardDiff.derivative(w -> f(w).z, w))
+end
+
+### numerical machinery for the generic derived queries (2-D)
+
+# squared distance from pos to the boundary point at parameter u, in the x-z plane
+function _dist²(shape::AbstractShape, u, pos::XYZ)
+  p = boundary_point(shape, u)
+  abs2(p.x - pos.x) + abs2(p.z - pos.z)
+end
+
+# Newton refinement of the nearest-point parameter, seeded near the global minimum;
+# converges to a stationary point so that AD duals propagate correctly (envelope theorem)
+function _newton_projection(shape::AbstractShape, u, pos::XYZ, maxstep)
+  for _ ∈ 1:32
+    p = boundary_point(shape, u)
+    x′, z′ = _dbdu(shape, u)
+    x″ = ForwardDiff.derivative(u -> _dbdu(shape, u)[1], u)
+    z″ = ForwardDiff.derivative(u -> _dbdu(shape, u)[2], u)
+    g = (p.x - pos.x) * x′ + (p.z - pos.z) * z′
+    g′ = x′^2 + z′^2 + (p.x - pos.x) * x″ + (p.z - pos.z) * z″
+    g′ == 0 && break
+    Δ = clamp(g / g′, -maxstep, maxstep)
+    u -= Δ
+    abs(Δ) < 1e-13 && break
+  end
+  u
+end
+
+# assemble the boundary_projection() result bundle at parameter u
+function _projection_bundle(shape::AbstractShape, u, pos::XYZ)
+  u = mod(u, 1)
+  p = boundary_point(shape, u)
+  n̂ = normal(shape, u)
+  κ = curvature(shape, u)
+  d = hypot(p.x - pos.x, p.z - pos.z)
+  (pos.x - p.x) * n̂.x + (pos.z - p.z) * n̂.z < 0 && (d = -d)
+  (u=u, point=p, normal=n̂, curvature=κ, distance=d)
+end
+
+# Newton refinement of a ray-boundary intersection on the parametric system
+# boundary_point(u) == origin + t * dir, in the x-z plane
+function _newton_ray(shape::AbstractShape, u, t, origin::XYZ, dir::XYZ)
+  for _ ∈ 1:32
+    p = boundary_point(shape, u)
+    x′, z′ = _dbdu(shape, u)
+    fx = p.x - origin.x - t * dir.x
+    fz = p.z - origin.z - t * dir.z
+    det = -x′ * dir.z + z′ * dir.x
+    det == 0 && break
+    Δu = (-fx * dir.z + fz * dir.x) / det
+    Δt = (x′ * fz - z′ * fx) / det
+    u -= Δu
+    t -= Δt
+    abs(Δu) < 1e-13 && abs(Δt) < 1e-13 && break
+  end
+  (u, t)
+end
+
+###############################################################################
+### shapes
+
+"""
+    Ellipse(x, z, a, b; θ=0)
+    Ellipse(; x, z, a, b, θ=0)
+
+Create a 2-D elliptical shape in the x–z plane, centered at `(x, z)` (in
+meters), with semi-major axis `a` and semi-minor axis `b` (in meters), and
+with the major axis rotated by angle `θ` (in radians) counter-clockwise from
+the x-axis.
+
+# Examples
+```julia-repl
+julia> Ellipse(500.0, -40.0, 20.0, 8.0)
+Ellipse(x=500.0, z=-40.0, a=20.0, b=8.0)
+
+julia> Ellipse(x=500, z=-40, a=20, b=8, θ=30u"°")
+Ellipse(x=500.0, z=-40.0, a=20.0, b=8.0, θ=0.5235987755982988)
+```
+"""
+struct Ellipse{T} <: AbstractShape
+  x::T
+  z::T
+  a::T
+  b::T
+  θ::T
+  function Ellipse(x, z, a, b, θ)
+    x = in_units(u"m", x)
+    z = in_units(u"m", z)
+    a = in_units(u"m", a)
+    b = in_units(u"m", b)
+    θ = in_units(u"rad", θ)
+    a > 0 || error("Semi-major axis must be positive")
+    b > 0 || error("Semi-minor axis must be positive")
+    x, z, a, b, θ = float.(promote(x, z, a, b, θ))
+    new{typeof(x)}(x, z, a, b, θ)
+  end
+end
+
+Ellipse(x, z, a, b; θ=0) = Ellipse(x, z, a, b, θ)
+Ellipse(; x, z, a, b, θ=0) = Ellipse(x, z, a, b, θ)
+
+function Base.show(io::IO, e::Ellipse)
+  print(io, "Ellipse(x=$(e.x), z=$(e.z), a=$(e.a), b=$(e.b)")
+  e.θ == 0 || print(io, ", θ=$(e.θ)")
+  print(io, ")")
+end
+
+Base.ndims(::Ellipse) = 2
+
+# world position of a point given in the ellipse frame
+function _eworld(e::Ellipse, px, pz)
+  sθ, cθ = sincos(e.θ)
+  xyz(e.x + cθ * px - sθ * pz, 0, e.z + sθ * px + cθ * pz)
+end
+
+# ellipse frame coordinates of a world position
+function _eframe(e::Ellipse, pos::XYZ)
+  sθ, cθ = sincos(e.θ)
+  dx = pos.x - e.x
+  dz = pos.z - e.z
+  (cθ * dx + sθ * dz, -sθ * dx + cθ * dz)
+end
+
+function boundary_point(e::Ellipse, u)
+  s, c = sincospi(2u)
+  _eworld(e, e.a * c, e.b * s)
+end
+
+function normal(e::Ellipse, u)
+  s, c = sincospi(2u)
+  nx = e.b * c
+  nz = e.a * s
+  m = hypot(nx, nz)
+  sθ, cθ = sincos(e.θ)
+  xyz((cθ * nx - sθ * nz) / m, 0, (sθ * nx + cθ * nz) / m)
+end
+
+function curvature(e::Ellipse, u)
+  s, c = sincospi(2u)
+  e.a * e.b / hypot(e.a * s, e.b * c)^3
+end
+
+function is_inside(e::Ellipse, pos::XYZ)
+  px, pz = _eframe(e, pos)
+  abs2(px / e.a) + abs2(pz / e.b) < 1
+end
+
+function bounding_box(e::Ellipse)
+  sθ, cθ = sincos(e.θ)
+  hx = hypot(e.a * cθ, e.b * sθ)
+  hz = hypot(e.a * sθ, e.b * cθ)
+  (min=xyz(e.x - hx, 0, e.z - hz), max=xyz(e.x + hx, 0, e.z + hz))
+end
+
+location(e::Ellipse) = xyz(e.x, 0, e.z)
+
+function boundary_projection(e::Ellipse, pos::XYZ)
+  # nearest point on the ellipse p(t) = (a cos t, b sin t) to q, in the ellipse frame:
+  # Newton on g(t) = (p - q)⋅p′ = (b² - a²) sin t cos t + a qx sin t - b qz cos t
+  qx, qz = _eframe(e, pos)
+  a = e.a
+  b = e.b
+  t = atan(a * qz, b * qx)
+  # coarse candidates guard against convergence to a non-nearest stationary point
+  f = t -> abs2(a * cos(t) - qx) + abs2(b * sin(t) - qz)
+  for t₀ ∈ (0:15) .* (π / 8)
+    f(t₀) < f(t) && (t = t₀ + 0 * t)
+  end
+  for _ ∈ 1:32
+    s, c = sincos(t)
+    g = (b^2 - a^2) * s * c + a * qx * s - b * qz * c
+    g′ = (b^2 - a^2) * (c^2 - s^2) + a * qx * c + b * qz * s
+    g′ == 0 && break
+    Δ = clamp(g / g′, -0.5, 0.5)
+    t -= Δ
+    abs(Δ) < 1e-13 && break
+  end
+  u = mod(t / 2π, 1)
+  p = boundary_point(e, u)
+  n̂ = normal(e, u)
+  d = hypot(p.x - pos.x, p.z - pos.z)
+  is_inside(e, pos) && (d = -d)
+  (u=u, point=p, normal=n̂, curvature=curvature(e, u), distance=d)
+end
+
+function intersect_ray(e::Ellipse, origin::XYZ, dir::XYZ)
+  # transform the ray to a frame where the ellipse is a unit circle and solve the quadratic
+  ox, oz = _eframe(e, origin)
+  sθ, cθ = sincos(e.θ)
+  dx = cθ * dir.x + sθ * dir.z
+  dz = -sθ * dir.x + cθ * dir.z
+  ox /= e.a
+  dx /= e.a
+  oz /= e.b
+  dz /= e.b
+  A = dx^2 + dz^2
+  A == 0 && return nothing
+  B = ox * dx + oz * dz
+  C = ox^2 + oz^2 - 1
+  Δ = B^2 - A * C
+  Δ < 0 && return nothing
+  t = (-B - √Δ) / A
+  t < 0 && (t = (-B + √Δ) / A)
+  t < 0 && return nothing
+  u = mod(atan(oz + t * dz, ox + t * dx) / 2π, 1)
+  (t=t, u=u, point=boundary_point(e, u), normal=normal(e, u), curvature=curvature(e, u))
+end
+
+"""
+    ParametricCurve(f)
+
+Wrap a function `f(u)` as a 2-D shape. The function must map a boundary
+parameter `u ∈ [0,1]` to a position on the boundary of the shape, tracing a
+closed curve counter-clockwise in the x–z plane (with `x` rightward and `z`
+upward) as `u` increases, so that automatically derived normals point outward.
+The position may be given in any form accepted by `xyz()` (e.g. an `(x, z)`
+tuple or an `XYZ` named tuple). The function must be differentiable if
+normals, curvatures or the generic derived queries are used.
+
+# Examples
+```julia-repl
+julia> circle = ParametricCurve(u -> (10 * cospi(2u), -40 + 10 * sinpi(2u)));
+
+julia> boundary_point(circle, 0.25)
+(x = 0.0, y = 0.0, z = -30.0)
+```
+"""
+struct ParametricCurve{F} <: AbstractShape
+  f::F
+end
+
+Base.ndims(::ParametricCurve) = 2
+boundary_point(s::ParametricCurve, u) = xyz(s.f(u))
+Base.show(io::IO, s::ParametricCurve) = print(io, "ParametricCurve($(s.f))")
+
+"""
+    ParametricSurface(f)
+
+Wrap a function `f(u, v)` as a 3-D shape. The function must map boundary
+parameters `(u, v) ∈ [0,1]²` to a position on the boundary of the shape,
+covering the full closed surface with a right-handed parametrization
+(`∂p/∂u × ∂p/∂v` pointing outward), so that automatically derived normals
+point outward. The position may be given in any form accepted by `xyz()`.
+The function must be differentiable if normals are used.
+"""
+struct ParametricSurface{F} <: AbstractShape
+  f::F
+end
+
+Base.ndims(::ParametricSurface) = 3
+boundary_point(s::ParametricSurface, u, v) = xyz(s.f(u, v))
+Base.show(io::IO, s::ParametricSurface) = print(io, "ParametricSurface($(s.f))")
+
+###############################################################################
+### scatterers
+
+"""
+Superclass for all scatterers. A scatterer is a discrete object in the water
+column that scatters sound.
+"""
+abstract type AbstractScatterer end
+
+"""
+    Scatterer(shape; boundary=RigidBoundary)
+    Scatterer(shape, boundary)
+
+Create a scatterer with the given `shape` and acoustic `boundary` condition.
+A scatterer is a non-penetrable object in the water column, described by its
+geometry (an [`AbstractShape`](@ref)) and the acoustic property of its surface
+(an `AbstractAcousticBoundary`, e.g. `RigidBoundary` for a sound-hard object
+or `PressureReleaseBoundary` for a sound-soft object such as a bubble cloud).
+
+Propagation models that support scatterers are expected to apply the boundary
+condition under a local tangent-plane (Kirchhoff) approximation: the reflection
+coefficient of the boundary is applied using the local surface normal at each
+interaction point. This approximation is valid when the local radius of
+curvature of the scatterer is much larger than the acoustic wavelength.
+
+# Examples
+```julia-repl
+julia> Scatterer(Ellipse(500.0, -40.0, 20.0, 8.0))
+Scatterer(Ellipse(x=500.0, z=-40.0, a=20.0, b=8.0), RigidBoundary)
+
+julia> Scatterer(Ellipse(500.0, -40.0, 20.0, 8.0), PressureReleaseBoundary)
+Scatterer(Ellipse(x=500.0, z=-40.0, a=20.0, b=8.0), PressureReleaseBoundary)
+```
+"""
+struct Scatterer{G<:AbstractShape,B<:AbstractAcousticBoundary} <: AbstractScatterer
+  shape::G
+  boundary::B
+end
+
+Scatterer(shape::AbstractShape; boundary=RigidBoundary) = Scatterer(shape, boundary)
+
+Base.show(io::IO, s::Scatterer) = print(io, "Scatterer(", s.shape, ", ", s.boundary, ")")
+
+location(s::Scatterer) = location(s.shape)
+
+"""
+    has_scatterers(env)
+
+Return `true` if the environment `env` has any scatterers in the water column,
+and `false` otherwise.
+"""
+has_scatterers(env::UnderwaterEnvironment) = !isempty(env.scatterers)
+
+# base number type of the geometry of a scatterer, for env_type()
+_geom_type(s::Scatterer) = _geom_type(s.shape)
+_geom_type(::Ellipse{T}) where {T} = T
+function _geom_type(shape::AbstractShape)
+  p = ndims(shape) == 2 ? boundary_point(shape, 0.0) : boundary_point(shape, 0.0, 0.0)
+  typeof(p.x)
+end

--- a/test/test_scatterers.jl
+++ b/test/test_scatterers.jl
@@ -1,0 +1,226 @@
+using TestItems
+
+@testitem "scatterers-construction" begin
+  @test Ellipse <: AbstractShape
+  e = Ellipse(500.0, -40.0, 20.0, 8.0)
+  @test e isa Ellipse
+  @test e == Ellipse(x=500, z=-40, a=20, b=8)
+  @test e == Ellipse(500u"m", -40.0u"m", 20u"m", 8000u"mm")
+  @test e == @inferred Ellipse(500.0, -40.0, 20.0, 8.0)
+  @test e isa Ellipse{Float64}
+  @test startswith(sprint(show, e), "Ellipse")
+  e = Ellipse(500, -40, 20, 8; θ=30u"°")
+  @test e.θ ≈ π/6
+  @test e == Ellipse(x=500, z=-40, a=20, b=8, θ=π/6)
+  @test_throws ErrorException Ellipse(0, 0, -1, 1)
+  @test_throws ErrorException Ellipse(0, 0, 1, 0)
+  s = Scatterer(e)
+  @test s isa Scatterer
+  @test Scatterer <: UnderwaterAcoustics.AbstractScatterer
+  @test s.shape === e
+  @test s.boundary === RigidBoundary
+  @test s == Scatterer(e, RigidBoundary)
+  @test Scatterer(e; boundary=PressureReleaseBoundary).boundary === PressureReleaseBoundary
+  @test startswith(sprint(show, s), "Scatterer")
+  @test location(s) == (x=500.0, y=0.0, z=-40.0)
+  @test location(e) == (x=500.0, y=0.0, z=-40.0)
+end
+
+@testitem "scatterers-geometry" begin
+  e = Ellipse(100.0, -50.0, 20.0, 8.0; θ=30u"°")
+  @test ndims(e) == 2
+  # points on the boundary satisfy the ellipse equation in the ellipse frame
+  onellipse(e, p) = begin
+    s, c = sincos(e.θ)
+    px = c * (p.x - e.x) + s * (p.z - e.z)
+    pz = -s * (p.x - e.x) + c * (p.z - e.z)
+    abs2(px / e.a) + abs2(pz / e.b) ≈ 1
+  end
+  for u ∈ 0:0.05:1
+    p = @inferred boundary_point(e, u)
+    @test p.y == 0
+    @test onellipse(e, p)
+  end
+  p0 = boundary_point(e, 0)
+  p1 = boundary_point(e, 1)
+  @test all(isapprox.(values(p0), values(p1); atol=1e-12))
+  # analytic normals are unit length and outward
+  for u ∈ 0:0.05:1
+    n = @inferred normal(e, u)
+    @test hypot(n.x, n.y, n.z) ≈ 1
+    p = boundary_point(e, u)
+    @test (p.x - e.x) * n.x + (p.z - e.z) * n.z > 0
+  end
+  # curvature of a circle is 1/r
+  circ = Ellipse(0.0, 0.0, 5.0, 5.0)
+  @test all(curvature(circ, u) ≈ 0.2 for u ∈ 0:0.1:1)
+  # curvature at the ends of the major/minor axes
+  e0 = Ellipse(0.0, 0.0, 4.0, 2.0)
+  @test curvature(e0, 0) ≈ 4 / 2^2
+  @test curvature(e0, 0.25) ≈ 2 / 4^2
+  # AD-derived normal/curvature from boundary_point() agree with analytic ones
+  pc = ParametricCurve(u -> boundary_point(e, u))
+  @test ndims(pc) == 2
+  for u ∈ 0:0.05:1
+    na = normal(e, u)
+    nd = normal(pc, u)
+    @test all(isapprox.(values(na), values(nd); atol=1e-10))
+    @test curvature(pc, u) ≈ curvature(e, u)
+  end
+  # sampled boundary is closed and on the ellipse
+  pts = boundary_points(e; n=64)
+  @test length(pts) == 65
+  @test all(isapprox.(values(pts[1]), values(pts[end]); atol=1e-12))
+  @test all(onellipse(e, p) for p ∈ pts)
+end
+
+@testitem "scatterers-queries" begin
+  e = Ellipse(100.0, -50.0, 20.0, 8.0; θ=30u"°")
+  pc = ParametricCurve(u -> boundary_point(e, u))
+  # is_inside
+  @test is_inside(e, (x=100.0, y=0.0, z=-50.0))
+  @test !is_inside(e, (x=150.0, y=0.0, z=-50.0))
+  # just outside / just inside the boundary (exactly on the boundary is float-ambiguous)
+  let p = boundary_point(e, 0.1), n = normal(e, 0.1), δ = 1e-6
+    @test !is_inside(e, (x=p.x + δ * n.x, y=0.0, z=p.z + δ * n.z))
+    @test is_inside(e, (x=p.x - δ * n.x, y=0.0, z=p.z - δ * n.z))
+  end
+  for x ∈ 70:5:130, z ∈ -65:2.5:-35
+    @test is_inside(pc, (x=Float64(x), y=0.0, z=Float64(z))) == is_inside(e, (x=Float64(x), y=0.0, z=Float64(z)))
+  end
+  # distance is signed, zero on the boundary, and matches offsets along the normal
+  for u ∈ 0:0.1:0.9
+    p = boundary_point(e, u)
+    n = normal(e, u)
+    @test abs(distance(e, p)) < 1e-8
+    for δ ∈ (0.1, 2.0)
+      pout = (x=p.x + δ * n.x, y=0.0, z=p.z + δ * n.z)
+      pin = (x=p.x - δ * n.x, y=0.0, z=p.z - δ * n.z)
+      @test distance(e, pout) ≈ δ
+      @test distance(e, pin) ≈ -δ
+      @test distance(pc, pout) ≈ δ atol=1e-6
+      @test distance(pc, pin) ≈ -δ atol=1e-6
+    end
+  end
+  # boundary_projection returns the nearest boundary point
+  p = boundary_point(e, 0.15)
+  n = normal(e, 0.15)
+  q = (x=p.x + 3n.x, y=0.0, z=p.z + 3n.z)
+  for shape ∈ (e, pc)
+    bp = boundary_projection(shape, q)
+    @test all(isapprox.(values(bp.point), values(p); atol=1e-6))
+    @test all(isapprox.(values(bp.normal), values(n); atol=1e-6))
+    @test bp.u ≈ 0.15 atol=1e-6
+    @test bp.distance ≈ 3
+    @test bp.curvature ≈ curvature(e, 0.15) atol=1e-6
+  end
+  # intersect_ray on an axis-aligned ellipse with known answers
+  e0 = Ellipse(0.0, 0.0, 4.0, 2.0)
+  pc0 = ParametricCurve(u -> boundary_point(e0, u))
+  for shape ∈ (e0, pc0)
+    hit = intersect_ray(shape, (x=-10.0, y=0.0, z=0.0), (x=1.0, y=0.0, z=0.0))
+    @test hit !== nothing
+    @test hit.t ≈ 6
+    @test hit.u ≈ 0.5
+    @test all(isapprox.(values(hit.point), (-4.0, 0.0, 0.0); atol=1e-9))
+    @test all(isapprox.(values(hit.normal), (-1.0, 0.0, 0.0); atol=1e-9))
+    @test hit.curvature ≈ 1
+    # from inside, the first boundary crossing along the ray is returned
+    hit = intersect_ray(shape, (x=0.0, y=0.0, z=0.0), (x=1.0, y=0.0, z=0.0))
+    @test hit.t ≈ 4
+    # misses
+    @test intersect_ray(shape, (x=-10.0, y=0.0, z=3.0), (x=1.0, y=0.0, z=0.0)) === nothing
+    @test intersect_ray(shape, (x=-10.0, y=0.0, z=0.0), (x=-1.0, y=0.0, z=0.0)) === nothing
+  end
+  # bounding box
+  bb = bounding_box(e0)
+  @test all(isapprox.(values(bb.min), (-4.0, 0.0, -2.0); atol=1e-9))
+  @test all(isapprox.(values(bb.max), (4.0, 0.0, 2.0); atol=1e-9))
+  bb = bounding_box(Ellipse(10.0, -20.0, 4.0, 2.0; θ=90u"°"))
+  @test all(isapprox.(values(bb.min), (8.0, 0.0, -24.0); atol=1e-9))
+  @test all(isapprox.(values(bb.max), (12.0, 0.0, -16.0); atol=1e-9))
+end
+
+@testitem "scatterers-parametric-surface" begin
+  # unit sphere as a parametric surface
+  sph = ParametricSurface() do u, v
+    s, c = sincospi(2u)
+    sv, cv = sincospi(v)
+    (x=10 + sv * c, y=sv * s, z=-40 - cv)
+  end
+  @test ndims(sph) == 3
+  p = boundary_point(sph, 0.25, 0.5)
+  @test all(isapprox.(values(p), (10.0, 1.0, -40.0); atol=1e-12))
+  n = normal(sph, 0.1, 0.3)
+  @test hypot(n.x, n.y, n.z) ≈ 1
+  # outward normal of a sphere is radial
+  p = boundary_point(sph, 0.1, 0.3)
+  @test all(isapprox.(values(n), (p.x - 10, p.y, p.z + 40); atol=1e-9))
+  @test curvature(sph, 0.1, 0.3) === missing
+  pts = boundary_points(sph; n=16)
+  @test length(pts) == 17^2
+  @test all(hypot(p.x - 10, p.y, p.z + 40) ≈ 1 for p ∈ pts)
+  bb = bounding_box(sph)
+  @test all(isapprox.(values(bb.min), (9.0, -1.0, -41.0); atol=1e-3))
+  @test all(isapprox.(values(bb.max), (11.0, 1.0, -39.0); atol=1e-3))
+end
+
+@testitem "scatterers-env" begin
+  s = Scatterer(Ellipse(500.0, -40.0, 20.0, 8.0))
+  env = UnderwaterEnvironment(scatterers=s)
+  @test env.scatterers == (s,)
+  @test UnderwaterEnvironment(scatterers=[s]).scatterers == (s,)
+  @test UnderwaterEnvironment(scatterers=(s,)).scatterers == (s,)
+  s2 = Scatterer(Ellipse(700.0, -20.0, 5.0, 5.0), PressureReleaseBoundary)
+  @test UnderwaterEnvironment(scatterers=(s, s2)).scatterers == (s, s2)
+  @test UnderwaterEnvironment().scatterers == ()
+  @test has_scatterers(env)
+  @test !has_scatterers(UnderwaterEnvironment())
+  @test occursin("scatterers", sprint(show, env))
+  @test !occursin("scatterers", sprint(show, UnderwaterEnvironment()))
+  @test (@inferred UnderwaterEnvironment(scatterers=(s,))) isa UnderwaterEnvironment
+  @test UnderwaterAcoustics.env_type(UnderwaterEnvironment()) === Float64
+  @test UnderwaterAcoustics.env_type(env) === Float64
+  import ForwardDiff
+  d = ForwardDiff.Dual(20.0, 1.0)
+  envd = UnderwaterEnvironment(scatterers=Scatterer(Ellipse(500.0, -40.0, d, 8.0)))
+  @test UnderwaterAcoustics.env_type(envd) <: ForwardDiff.Dual
+  # custom shapes work too
+  envp = UnderwaterEnvironment(scatterers=Scatterer(ParametricCurve(u -> (500 + 10cospi(2u), -40 + 10sinpi(2u)))))
+  @test UnderwaterAcoustics.env_type(envp) === Float64
+end
+
+@testitem "scatterers-models" begin
+  env = UnderwaterEnvironment(bathymetry=100.0, scatterers=Scatterer(Ellipse(500.0, -40.0, 20.0, 8.0)))
+  @test_throws ErrorException PekerisRayTracer(env)
+  @test_throws ErrorException PekerisModeSolver(env)
+  @test_throws ErrorException AdiabaticExt(PekerisModeSolver, env)
+end
+
+@testitem "scatterers-∂" begin
+  import ForwardDiff
+  # differentiable geometry wrt shape parameters
+  q = (x=150.0, y=0.0, z=-45.0)
+  f = p -> distance(Ellipse(p[1], p[2], p[3], p[4]; θ=p[5]), q)
+  p₀ = [100.0, -50.0, 20.0, 8.0, 0.5]
+  g = ForwardDiff.gradient(f, p₀)
+  @test all(isfinite, g)
+  # compare with central finite differences
+  for i ∈ eachindex(p₀)
+    h = 1e-6
+    p⁺ = copy(p₀); p⁺[i] += h
+    p⁻ = copy(p₀); p⁻[i] -= h
+    @test g[i] ≈ (f(p⁺) - f(p⁻)) / 2h atol=1e-4
+  end
+  # gradient of the signed distance wrt position is the unit outward direction,
+  # both through the analytic path and the generic Newton fallback
+  e = Ellipse(100.0, -50.0, 20.0, 8.0; θ=0.5)
+  pc = ParametricCurve(u -> boundary_point(e, u))
+  for shape ∈ (e, pc)
+    gp = ForwardDiff.gradient(x -> distance(shape, (x=x[1], y=0.0, z=x[2])), [150.0, -45.0])
+    @test hypot(gp...) ≈ 1
+  end
+  # boundary_point is differentiable wrt shape parameters
+  gb = ForwardDiff.derivative(a -> boundary_point(Ellipse(0.0, 0.0, a, 2.0), 0.0).x, 4.0)
+  @test gb ≈ 1
+end


### PR DESCRIPTION
## Summary

Adds **scatterers** — objects in the water column with a geometric shape and an acoustic surface boundary condition — to the environmental description, and defines the geometry API that an external ray-tracing propagation model (e.g. RaySolver in `AcousticRayTracers.jl`) can build against. **API + documentation only**: scattering physics is deliberately deferred to external models; built-in models reject scatterer-bearing environments with a clear error.

- `AbstractShape`: a shape is defined by a parametric map of its closed boundary over a unit parameter domain — `Base.ndims(shape)` + `boundary_point(shape, u...)` are the only required methods. `normal`/`curvature` are analytic if the shape provides them, else AD-derived (ForwardDiff) from `boundary_point`.
- Framework-owned derived queries with generic differentiable fallbacks: `distance` (signed, negative inside, exact near the boundary), `boundary_projection`, `intersect_ray`, `is_inside`, `boundary_points`, `bounding_box`, `location`.
- First concrete shape: 2-D `Ellipse` (analytic overrides for all hot paths). `ParametricCurve`/`ParametricSurface` wrap a bare function as a shape.
- `Scatterer` composes a shape with an existing `AbstractAcousticBoundary` (default `RigidBoundary`), to be applied by models under a local tangent-plane (Kirchhoff) approximation.
- `UnderwaterEnvironment` gains a `scatterers` field (default `()`; single/vector/tuple normalized to a tuple); `env_type` promotes through scatterer geometry; new `has_scatterers`.
- `PekerisRayTracer`, `PekerisModeSolver` and `AdiabaticExt` error cleanly when handed scatterers.
- Plot recipe draws scatterer outlines; new `qdocs/scatterers.qmd` guide, extension-author section in `ext.qmd`, API reference in `api.qmd`.
- ForwardDiff becomes a direct dependency (already in the dependency tree via NonlinearSolve).

**BREAKING**: the positional `UnderwaterEnvironment` constructor takes an additional `scatterers` argument (keyword construction is unaffected) — hence the minor version bump to 0.8.0.

## Testing

- Full test suite passes (992 assertions incl. Aqua); 484 new assertions in `test/test_scatterers.jl`: construction/Unitful/type-stability, analytic vs AD-derived geometry agreement, analytic vs generic-fallback agreement for all derived queries, environment integration, model rejection, and AD checks (gradients match finite differences; ∇distance w.r.t. position is unit-norm through both analytic and generic Newton paths).
- Plot recipe verified via `RecipesBase.apply_recipe`.
- All new jdoc bindings resolve and all doc-page code examples execute.
