### PR TITLE
Make AdiabaticExt forward-mode differentiable

### DIFF
--- a/src/adiabatic.jl
+++ b/src/adiabatic.jl
@@ -16,6 +16,10 @@ Adiabatic mode models are usually not reciprocal, i.e., exchanging a source and
 receiver changes the answer. This is because the bathymetry is assumed to have
 azimuthal symmetry around the source. In `reciprocal` mode, the adiabatic
 computation is modified to ensure reciprocity, but azimuthal symmetry is lost.
+
+If the underlying `model` is differentiable, `AdiabaticExt` supports
+forward-mode automatic differentiation (e.g. ForwardDiff). Reverse-mode
+automatic differentiation is currently not supported.
 """
 struct AdiabaticExt{T1,T2,T3} <: AbstractModePropagationModel
   env::T1
@@ -103,10 +107,12 @@ function acoustic_field(pm::AdiabaticExt, tx::AbstractAcousticSource, rxs::Abstr
   x0 = location(tx).x
   z0 = -value(pm.env.bathymetry, (x=x0, y=0.0, z=0.0))
   i0 = something(findfirst(≥(x0), xs), length(xs)+1)
-  fld = zeros(ComplexF64, size(rxs))
   tx_modes = _cached_arrivals(cache, z0, dz)
+  m₁ = tx_modes[findfirst(!isnothing, tx_modes)]
+  T = complex(promote_type(typeof(float(x0)), typeof(real(m₁.kᵣ)), typeof(real(m₁.ψ(location(tx).z)))))
+  fld = zeros(T, size(rxs))
   for m ∈ eachindex(tx_modes)
-    kri = zeros(ComplexF64, size(xs))
+    kri = zeros(T, size(xs))
     # compute kr-integral for all receivers on the right of the source
     x = x0
     for i ∈ i0:length(xs)
@@ -185,10 +191,10 @@ end
 
 _model(pm::AdiabaticExt{T1,T2,T3}) where {T1,T2,T3} = T3
 
-struct ModeCache{T}
-  zs::Vector{Float64}
+struct ModeCache{Tz,T}
+  zs::Vector{Tz}
   modes::Vector{Vector{T}}
-  ModeCache(T) = new{T}(Float64[], Vector{T}[])
+  ModeCache(Tz, T) = new{Tz,T}(Tz[], Vector{T}[])
 end
 
 function _cached_arrivals(cache, z, dz)
@@ -222,7 +228,8 @@ end
 function _precompute_arrivals(pm, tx, tx_depth, rx, min_depth, max_depth, dz)
   n = ceil(Int, (max_depth - min_depth) / 2dz) + 1
   arr = _compute_arrivals(pm, tx, -tx_depth, rx)
-  cache = ModeCache(eltype(arr))
+  Tz = promote_type(typeof(float(-tx_depth)), typeof(float(min_depth)), typeof(float(max_depth)))
+  cache = ModeCache(Tz, eltype(arr))
   _cache_arrivals(cache, -tx_depth, arr)
   for z ∈ range(-max_depth, -min_depth; length=n)
     i = searchsortedlast(cache.zs, z)

--- a/test/test_pekeris.jl
+++ b/test/test_pekeris.jl
@@ -366,3 +366,28 @@ end
   @test [a.v for a ∈ arr1] == [a.v for a ∈ arr2]
   @test [a.vₚ for a ∈ arr1] == [a.vₚ for a ∈ arr2]
 end
+
+@testitem "pekeris-modes-adiabatic-∂" begin
+  using DifferentiationInterface
+  import ForwardDiff, FiniteDifferences
+  fd = AutoFiniteDifferences(fdm=FiniteDifferences.central_fdm(5, 1))
+  function ℳ((D1, D2, R, d1, d2, f, c))
+    env = UnderwaterEnvironment(
+      bathymetry = SampledField([D1, D2, D1]; x=[0.0, 2000.0, 5000.0]),
+      soundspeed = c,
+      density = 1000,
+      seabed = FluidBoundary(2000, 2000)
+    )
+    pm = AdiabaticExt(PekerisModeSolver, env; dx=10.0, dz=0.1)
+    transmission_loss(pm, AcousticSource((x=0.0, z=-d1), f), AcousticReceiver((x=R, z=-d2)))
+  end
+  # parameters chosen off the internal integration/cache grids, away from mode cut-on/cut-off
+  x = [201.3, 151.7, 3013.7, 21.4, 141.3, 307.0, 1503.0]
+  ∇ℳ = gradient(ℳ, AutoForwardDiff(), x)
+  @test all(isfinite, ∇ℳ)
+  # transmission loss is discontinuous in the bathymetry samples (D1, D2) at finite-difference
+  # scale due to the internal depth-grid mode cache, so only the remaining components are
+  # compared against a finite-difference reference
+  @test ∇ℳ[3:7] ≈ gradient(ℳ, fd, x)[3:7] rtol=1e-4
+  # FIXME reverse mode (Zygote) unsupported: AdiabaticExt integration is mutation-heavy
+end


### PR DESCRIPTION
Closes #68.

`AdiabaticExt` was not differentiable out of the box: under ForwardDiff, the Dual-valued source depth failed to `push!` into `ModeCache.zs::Vector{Float64}`, and the `ComplexF64`-typed `fld`/`kri` accumulators in `acoustic_field` would have dropped Dual parts next.

## Changes

- `ModeCache` is now generic in its depth-key type, constructed from the promoted bathymetry/depth types.
- The field and kᵣ-integral accumulators derive their complex element type from the mode types instead of hardcoding `ComplexF64`.
- Docstring notes that `AdiabaticExt` supports forward-mode AD when the underlying model does; reverse mode remains unsupported (the integration loops and mode cache are mutation-heavy) and could be a follow-up.

## Tests

New `@testitem "pekeris-modes-adiabatic-∂"` differentiates `transmission_loss` through `AdiabaticExt(PekerisModeSolver)` with sloped `SampledField` bathymetry w.r.t. 7 parameters. ForwardDiff matches a central finite-difference reference to `rtol=1e-4` for range, source/receiver depths, frequency, and soundspeed; the bathymetry-sample gradients are only checked for finiteness, since the internal depth-grid mode cache makes TL locally discontinuous in them at finite-difference scale (verified manually that ForwardDiff gives the smooth-path derivative).

Full test suite passes (1024/1024).