### PR TITLE
Add field derivative API

### DIFF
--- a/qdocs/fields.qmd
+++ b/qdocs/fields.qmd
@@ -34,6 +34,14 @@ To get the value of a field at a given position, we use the `value` function:
 jdoc(UnderwaterAcoustics, :value)
 ```
 
+Some propagation models (e.g. ray tracers) also require spatial derivatives of a field. These can be obtained using the `∂` function:
+
+```{julia}
+#| echo: false
+#| output: asis
+jdoc(UnderwaterAcoustics, :∂)
+```
+
 We can also check if a field is constant or range-dependent:
 ```{julia}
 #| echo: false

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -542,6 +542,47 @@ end
 (v::SampledFieldXY)(pos::XYZ) = v.f(pos.x, pos.y)
 (v::SampledFieldXYZ)(pos::XYZ) = v.f(pos.x, pos.y, pos.z)
 
+# analytic derivatives for linearly interpolated 1-D fields; within a segment
+# the derivative is the segment slope, at interior knots it is defined as the
+# mean of the adjacent segment slopes (consistent with central finite
+# differences), at the end knots it is the one-sided interior slope, and
+# outside the sampled domain it is zero (consistent with `Flat()` extrapolation)
+function _linear∂(f, knots, x)
+  ks = issorted(knots) ? knots : sort(knots)
+  n = length(ks)
+  T = typeof(f(first(ks)) / one(first(ks)))
+  (x < first(ks) || x > last(ks) || n < 2) && return zero(T)
+  slope(k) = (f(ks[k+1]) - f(ks[k])) / (ks[k+1] - ks[k])
+  k = searchsortedlast(ks, x)
+  x == ks[k] || return slope(k)::T
+  k == 1 && return slope(1)::T
+  k == n && return slope(n - 1)::T
+  T((slope(k - 1) + slope(k)) / 2)
+end
+
+# the coordinate is stripped of dual numbers since the slope is piecewise
+# constant (zero derivative w.r.t. position almost everywhere), but the field
+# values retain any dual numbers they carry
+_undual(x) = x
+_undual(x::ForwardDiff.Dual) = _undual(ForwardDiff.value(x))
+
+function ∂(v::SampledFieldZ, pos, i::Symbol)
+  v.interp === Linear() || return invoke(∂, Tuple{DepthDependent,Any,Symbol}, v, pos, i)
+  i === :z || return zero(value(v, pos) / one(xyz(pos).z))
+  _linear∂(v.f, v.zrange, _undual(xyz(pos).z))
+end
+
+function ∂(v::SampledFieldX, pos, i::Symbol)
+  v.interp === Linear() || return invoke(∂, Tuple{DepthDependent,Any,Symbol}, v, pos, i)
+  i === :x || return zero(value(v, pos) / one(xyz(pos).x))
+  _linear∂(v.f, v.xrange, _undual(xyz(pos).x))
+end
+
+function ∂(v::Union{SampledFieldZ,SampledFieldX}, pos, i::Symbol, j::Symbol)
+  v.interp === Linear() || return invoke(∂, Tuple{DepthDependent,Any,Symbol,Symbol}, v, pos, i, j)
+  zero(value(v, pos) / one(xyz(pos).z)^2)
+end
+
 Base.show(io::IO, v::SampledFieldZ) = print(io, "SampledField(z-varying, $(length(v.zrange)) samples)")
 Base.show(io::IO, v::SampledFieldX) = print(io, "SampledField(x-varying, $(length(v.xrange)) samples)")
 Base.show(io::IO, v::SampledFieldXZ) = print(io, "SampledField(xz-varying, $(length(v.xrange))×$(length(v.zrange)) samples)")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,6 @@
 import Unitful: ustrip, Quantity, Units, @u_str, uconvert, dimension
-export @u_str, °, XYZ, is_constant, is_range_dependent, value
+import ForwardDiff
+export @u_str, °, XYZ, is_constant, is_range_dependent, value, ∂
 
 ################################################################################
 # unit conversion utilities, with default units if none are specified
@@ -130,6 +131,49 @@ value(q, pos) = q
 value(q::DepthDependent, pos) = q(xyz(pos))
 value(q) = value(q, nothing)
 value(q::DepthDependent) = error("Position not specified")
+
+# coordinate access/replacement helpers for derivative computation
+_coord(p::XYZ, i::Symbol) = getproperty(p, i)
+_setcoord(p::XYZ, i::Symbol, w) =
+  i === :x ? (x=w, y=p.y, z=p.z) :
+  i === :y ? (x=p.x, y=w, z=p.z) :
+  i === :z ? (x=p.x, y=p.y, z=w) :
+  throw(ArgumentError("Unknown coordinate: $i"))
+
+"""
+    ∂(q, pos, i)
+    ∂(q, pos, i, j)
+
+Get the first derivative `∂q/∂i` or second derivative `∂²q/∂i∂j` of the varying
+quantity `q` at the given position `pos`, where `i` and `j` are coordinate names
+(`:x`, `:y` or `:z`). `pos` may be specified as a `(x, y, z)` tuple, a `(x, z)`
+tuple, or a `z` value.
+
+If a field does not provide analytic derivatives, they are derived from
+`value()` using automatic differentiation. Fields whose interpolation makes
+derivatives ill-defined at some points (e.g. knots of a piecewise-linear
+interpolation) may define derivatives there using the surrounding context
+(e.g. mean of the adjacent segment slopes).
+
+# Examples
+```julia-repl
+∂(q, -10, :z)          # ∂q/∂z of a depth-dependent quantity at z=-10
+∂(q, (1000,-10), :x)   # ∂q/∂x of a position-dependent quantity at x=1000, z=-10
+∂(q, -10, :z, :z)      # ∂²q/∂z² at z=-10
+```
+"""
+∂(q, pos, i::Symbol) = zero(value(q, pos))
+∂(q, pos, i::Symbol, j::Symbol) = zero(value(q, pos))
+
+function ∂(q::DepthDependent, pos, i::Symbol)
+  p = xyz(pos)
+  ForwardDiff.derivative(w -> value(q, _setcoord(p, i, w)), _coord(p, i))
+end
+
+function ∂(q::DepthDependent, pos, i::Symbol, j::Symbol)
+  p = xyz(pos)
+  ForwardDiff.derivative(w -> ∂(q, _setcoord(p, j, w), i), _coord(p, j))
+end
 
 """
     minimum(q)

--- a/test/test_api_stdlib.jl
+++ b/test/test_api_stdlib.jl
@@ -338,6 +338,55 @@ end
   @test @inferred(value(fld, (x=1.0, y=1.0, z=1.0))) == 2.0
 end
 
+@testitem "∂" begin
+  using ForwardDiff
+  using FiniteDifferences
+  # constants have zero derivatives
+  @test @inferred(∂(1500.0, (0.0, 0.0, -10.0), :z)) == 0.0
+  @test @inferred(∂(1500.0, (0.0, 0.0, -10.0), :z, :z)) == 0.0
+  # linearly interpolated z-field: interior slopes, knot mean, end knots, flat outside
+  fld = SampledField([1500.0, 1520.0, 1510.0]; z=[0.0, -10.0, -30.0])
+  @test ∂(fld, -5.0, :z) ≈ -2.0
+  @test ∂(fld, -20.0, :z) ≈ 0.5
+  @test ∂(fld, -10.0, :z) ≈ (-2.0 + 0.5) / 2    # interior knot → mean of adjacent slopes
+  @test ∂(fld, 0.0, :z) ≈ -2.0                  # end knot → one-sided interior slope
+  @test ∂(fld, -30.0, :z) ≈ 0.5
+  @test ∂(fld, 5.0, :z) == 0.0                  # outside → flat extrapolation
+  @test ∂(fld, -40.0, :z) == 0.0
+  @test ∂(fld, -5.0, :x) == 0.0
+  @test ∂(fld, -5.0, :z, :z) == 0.0             # piecewise linear
+  @test ∂(fld, -10.0, :z, :z) == 0.0
+  # linearly interpolated x-field
+  fld = SampledField([200.0, 150.0, 200.0]; x=[0.0, 2000.0, 5000.0])
+  @test ∂(fld, (1000.0, 0.0, 0.0), :x) ≈ -0.025
+  @test ∂(fld, (3000.0, 0.0, 0.0), :x) ≈ 1/60
+  @test ∂(fld, (2000.0, 0.0, 0.0), :x) ≈ (-0.025 + 1/60) / 2
+  @test ∂(fld, (1000.0, 0.0, 0.0), :z) == 0.0
+  @test ∂(fld, (1000.0, 0.0, 0.0), :x, :x) == 0.0
+  # cubic spline z-field: generic AD fallback vs finite differences
+  fld = SampledField([1500.0, 1520.0, 1510.0, 1500.0]; z=0.0:-10.0:-30.0, interp=CubicSpline())
+  fdm1 = central_fdm(5, 1)
+  fdm2 = central_fdm(5, 2)
+  for z ∈ (-4.0, -15.0, -22.0)
+    @test ∂(fld, z, :z) ≈ fdm1(w -> value(fld, w), z) atol=1e-6
+    @test ∂(fld, z, :z, :z) ≈ fdm2(w -> value(fld, w), z) atol=1e-4
+  end
+  # generic AD fallback for a custom field matches the hand derivative
+  struct QuadraticSSP <: UnderwaterAcoustics.DepthDependent end
+  (::QuadraticSSP)(pos::XYZ) = 1500.0 + 0.1 * pos.z^2
+  ssp = QuadraticSSP()
+  @test ∂(ssp, -10.0, :z) ≈ -2.0
+  @test ∂(ssp, -10.0, :z, :z) ≈ 0.2
+  @test ∂(ssp, (5.0, 0.0, -10.0), :x) == 0.0
+  # dual-safety: outer AD over ∂ runs at and off knots
+  fld = SampledField([1500.0, 1520.0, 1510.0]; z=[0.0, -10.0, -30.0])
+  @test ForwardDiff.derivative(w -> ∂(fld, w, :z), -5.0) == 0.0
+  @test ForwardDiff.derivative(w -> ∂(fld, w, :z), -10.0) == 0.0
+  # derivatives w.r.t. field parameters flow through the analytic path
+  g = ForwardDiff.gradient(v -> ∂(SampledField(v; z=[0.0, -10.0, -30.0]), -5.0, :z), [1500.0, 1520.0, 1510.0])
+  @test g ≈ [1/10, -1/10, 0.0]
+end
+
 @testitem "noise" begin
   @test WhiteGaussianNoise <: UnderwaterAcoustics.AbstractNoiseModel
   @test RedGaussianNoise <: UnderwaterAcoustics.AbstractNoiseModel


### PR DESCRIPTION
## Summary

Adds `∂` — a framework-owned API to query spatial derivatives of environmental fields — following the analytic-or-AD pattern established by the shape geometry API in #86:

- `∂(q, pos, i)` / `∂(q, pos, i, j)`: first and second derivatives of a field along coordinates `i, j ∈ (:x, :y, :z)`, exported from `utils.jl` next to `value()`. Constants return typed zeros; `DepthDependent`/`PositionDependent` fields get a generic ForwardDiff fallback over `value()`, so any existing field works unchanged.
- Analytic overrides for linearly interpolated `SampledFieldZ`/`SampledFieldX`: exact segment slopes, with a defined convention at knots where AD is otherwise arbitrary — interior knots use the mean of the adjacent segment slopes (consistent with central finite differences), end knots the one-sided interior slope, and zero outside the sampled domain (consistent with `Flat()` extrapolation). Second derivatives are identically zero. Derivatives w.r.t. field *parameters* (sample values, knot positions) flow through both paths, so outer AD over environments built from dual numbers keeps working.
- Cubic-spline and multi-dimensional sampled fields stay on the generic AD fallback for now.
- Docs in `fields.qmd`; new `∂` testitem (constants, knot conventions, cubic vs FiniteDifferences, custom-field fallback, dual-safety, gradients w.r.t. sample values).

Motivation: lets ray tracers (e.g. `RaySolver` in AcousticRayTracers.jl) obtain `∂c`, `∂²c` and boundary slope/curvature without nested ForwardDiff over `value()`, addressing AD-tool interference, ill-defined knot derivatives, and enabling curved-boundary reflection corrections (org-arl/AcousticRayTracers.jl#19, org-arl/AcousticRayTracers.jl#20). Non-breaking addition, intended to ship as part of the unreleased 0.8.0.

## Testing

Full test suite passes (1024 assertions incl. Aqua); 32 new assertions in the `∂` testitem.